### PR TITLE
Add tablet pulpit mode screen timeout bug

### DIFF
--- a/Bugs.md
+++ b/Bugs.md
@@ -20,7 +20,18 @@ This file tracks bugs that need to be addressed in future releases.
 
 ## Medium Priority
 
-*No medium priority bugs currently reported*
+### 🟡 Screen Turns Off in Tablet Pulpit Mode
+- **Platform:** Tablet
+- **Description:** When on tablet in pulpit mode, screen should be prevented from turning off
+- **Reproduction:**
+  1. Open app on tablet device
+  2. Switch to pulpit mode
+  3. Screen turns off after timeout period
+  4. Expected: Screen should stay on during pulpit mode
+- **Status:** Not fixed
+- **Priority:** Medium
+- **Assigned:** TBD
+- **Date Reported:** 2025-01-27
 
 ---
 


### PR DESCRIPTION
Add a new medium priority bug to `Bugs.md` to prevent the screen from turning off in tablet pulpit mode.

---
<a href="https://cursor.com/background-agent?bcId=bc-53729505-2836-4f77-8b71-8aa82f6b9970"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-53729505-2836-4f77-8b71-8aa82f6b9970"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

